### PR TITLE
Added 'make_ParameterSet(std::string const &filename, fhicl::Paramete…

### DIFF
--- a/fhiclcpp/make_ParameterSet.h
+++ b/fhiclcpp/make_ParameterSet.h
@@ -15,6 +15,11 @@ inline ParameterSet make_ParameterSet(std::string const &filename) {
 
   return parse_fhicl_document(doc);
 }
+
+inline void make_ParameterSet(std::string const &filename, ParameterSet& pset){  
+  pset = make_ParameterSet(filename);
+}
+
 } // namespace fhicl
 
 #endif


### PR DESCRIPTION
…rSet &pset)' method that modifies the reference argument rather than returning a parameter set.